### PR TITLE
Fix lint

### DIFF
--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-""" Unit tests for backup.py """
+"""Unit tests for backup.py"""
 import json
 import unittest
 from pathlib import Path

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-""" Unit tests for cli.py """
+"""Unit tests for cli.py"""
 import argparse
 import unittest
 from io import StringIO
@@ -116,7 +116,7 @@ class TestMakeParser(unittest.TestCase):
         parser = make_cli_parser()
         with self.assertRaises(SystemExit):
             parser.parse_args(["--exclude-charm", "a-charm"])
-        self.assertRegexpMatches(mock_stderr.getvalue(), r"a-charm")
+        self.assertRegex(mock_stderr.getvalue(), r"a-charm")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-""" Unit tests for config.py """
+"""Unit tests for config.py"""
 import unittest
 
 from jujubackupall.config import Config

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-""" Unit tests for cli.py """
+"""Unit tests for cli.py"""
 import unittest
 from collections import namedtuple
 from pathlib import Path

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-""" Unit tests for utils.py """
+"""Unit tests for utils.py"""
 import unittest
 from concurrent.futures import TimeoutError
 from unittest.mock import Mock, patch


### PR DESCRIPTION
- fix lint by running format
- replace assertRegexpMatches to assertRegex because it was removed on newer python versions