### PR TITLE
Change to self-hosted runner for func tests

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -162,24 +162,34 @@ jobs:
         # https://documentation.ubuntu.com/lxd/latest/server/#server-configuration
         # https://sites.google.com/canonical.com/support/support-labs/se-cloud
         run: |
+          echo "=== Checking proxy availability ==="
+          echo "Proxy from environment: http_proxy=${http_proxy:-not set}, https_proxy=${https_proxy:-not set}"
+
+          # Resolve squid.internal to IP address
+          SQUID_IP=$(getent hosts squid.internal | awk '{ print $1 }' | head -1)
+          if [ -z "$SQUID_IP" ]; then
+            echo "WARNING: Cannot resolve squid.internal, using hostname"
+            PROXY_URL="http://squid.internal:3128"
+          else
+            echo "Resolved squid.internal to: $SQUID_IP"
+            PROXY_URL="http://${SQUID_IP}:3128"
+          fi
+
+          echo "Testing proxy connectivity: $PROXY_URL"
+          curl -x "$PROXY_URL" -I https://cloud-images.ubuntu.com --connect-timeout 5 || echo "WARNING: Proxy test failed"
+
           echo "=== Configuring LXD proxy: ==="
-          # Set up proxy configuration for LXD's default profile to ensure
-          # containers can access external network through the proxy
-          lxc config set core.proxy_http http://squid.internal:3128
-          lxc config set core.proxy_https http://squid.internal:3128
-          lxc config set core.proxy_ignore_hosts "localhost,127.0.0.1,10.149.0.0/16,10.0.0.0/8"
-
           # Configure the default profile to pass proxy environment variables to containers
-          lxc profile set default environment.http_proxy http://squid.internal:3128
-          lxc profile set default environment.https_proxy http://squid.internal:3128
-          lxc profile set default environment.no_proxy "localhost,127.0.0.1,10.149.0.0/16,10.0.0.0/8"
+          lxc profile set default environment.HTTP_PROXY "$PROXY_URL"
+          lxc profile set default environment.HTTPS_PROXY "$PROXY_URL"
+          lxc profile set default environment.NO_PROXY "localhost,127.0.0.1,10.149.0.0/16,10.0.0.0/8"
 
-          echo "=== Verifying LXD proxy configuration ==="
-          lxc config show | grep proxy || true
-          lxc profile show default | grep -A3 environment || true
+          echo "=== Verifying LXD profile configuration ==="
+          lxc profile show default | grep -A10 environment || true
 
           echo "=== Testing container connectivity ==="
           lxc launch ubuntu:22.04 test-proxy-connectivity
+          sleep 10
           lxc exec test-proxy-connectivity -- cloud-init status --wait || true
           lxc exec test-proxy-connectivity -- apt-get update || echo "APT update failed"
           lxc exec test-proxy-connectivity -- curl -I https://ubuntu.com || echo "Curl failed"

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -131,7 +131,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [[self-hosted-linux-amd64-noble-medium]]
+        runs-on: [[self-hosted-linux-amd64-noble-xlarge]]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -167,9 +167,6 @@ jobs:
           echo "Testing package installation:"
           lxc exec test-connectivity -- apt-get update
 
-          echo "Testing direct connectivity:"
-          lxc exec test-connectivity -- ping -c 3 8.8.8.8 || echo "Ping failed"
-
           echo "Testing HTTPS connectivity:"
           lxc exec test-connectivity -- curl -I https://ubuntu.com || echo "Curl to ubuntu.com failed"
 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -155,6 +155,19 @@ jobs:
         with:
           provider: lxd
           juju-channel: 3.6/stable
+          bootstrap-constraints: "cores=2 mem=4G"
+          
+      - name: Verify LXD is working
+        run: |
+          echo "=== LXD Network Configuration ==="
+          sudo lxc network show lxdbr0
+          echo "=== LXD Storage Configuration ==="
+          sudo lxc storage info default
+          echo "=== Testing LXD container creation ==="
+          sudo lxc launch ubuntu:22.04 test-lxd-connectivity
+          sudo lxc exec test-lxd-connectivity -- cloud-init status --wait || true
+          sudo lxc exec test-lxd-connectivity -- ping -c 3 8.8.8.8 || echo "Warning: No external connectivity"
+          sudo lxc delete test-lxd-connectivity --force
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -155,19 +155,35 @@ jobs:
         with:
           provider: lxd
           juju-channel: 3.6/stable
-          bootstrap-constraints: "cores=2 mem=4G"
-          
-      - name: Verify LXD is working
+
+      - name: Configure LXD proxy for PS7 environment
+        # Refs:
+        # https://canonical-self-hosted-github-runner-docs.readthedocs-hosted.com/en/latest/usage/faq/how-to-access-external-network
+        # https://documentation.ubuntu.com/lxd/latest/server/#server-configuration
+        # https://sites.google.com/canonical.com/support/support-labs/se-cloud
         run: |
-          echo "=== LXD Network Configuration ==="
-          sudo lxc network show lxdbr0
-          echo "=== LXD Storage Configuration ==="
-          sudo lxc storage info default
-          echo "=== Testing LXD container creation ==="
-          sudo lxc launch ubuntu:22.04 test-lxd-connectivity
-          sudo lxc exec test-lxd-connectivity -- cloud-init status --wait || true
-          sudo lxc exec test-lxd-connectivity -- ping -c 3 8.8.8.8 || echo "Warning: No external connectivity"
-          sudo lxc delete test-lxd-connectivity --force
+          echo "=== Configuring LXD proxy: ==="
+          # Set up proxy configuration for LXD's default profile to ensure
+          # containers can access external network through the proxy
+          lxc config set core.proxy_http http://squid.internal:3128
+          lxc config set core.proxy_https http://squid.internal:3128
+          lxc config set core.proxy_ignore_hosts "localhost,127.0.0.1,10.149.0.0/16,10.0.0.0/8"
+
+          # Configure the default profile to pass proxy environment variables to containers
+          lxc profile set default environment.http_proxy http://squid.internal:3128
+          lxc profile set default environment.https_proxy http://squid.internal:3128
+          lxc profile set default environment.no_proxy "localhost,127.0.0.1,10.149.0.0/16,10.0.0.0/8"
+
+          echo "=== Verifying LXD proxy configuration ==="
+          lxc config show | grep proxy || true
+          lxc profile show default | grep -A3 environment || true
+
+          echo "=== Testing container connectivity ==="
+          lxc launch ubuntu:22.04 test-proxy-connectivity
+          lxc exec test-proxy-connectivity -- cloud-init status --wait || true
+          lxc exec test-proxy-connectivity -- apt-get update || echo "APT update failed"
+          lxc exec test-proxy-connectivity -- curl -I https://ubuntu.com || echo "Curl failed"
+          lxc delete test-proxy-connectivity --force
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -156,44 +156,27 @@ jobs:
           provider: lxd
           juju-channel: 3.6/stable
 
-      - name: Configure LXD proxy for PS7 environment
-        # Refs:
-        # https://canonical-self-hosted-github-runner-docs.readthedocs-hosted.com/en/latest/usage/faq/how-to-access-external-network
-        # https://documentation.ubuntu.com/lxd/latest/server/#server-configuration
-        # https://sites.google.com/canonical.com/support/support-labs/se-cloud
+      - name: Verify LXD container connectivity
         run: |
-          echo "=== Checking proxy availability ==="
-          echo "Proxy from environment: http_proxy=${http_proxy:-not set}, https_proxy=${https_proxy:-not set}"
+          echo "=== Testing LXD container connectivity ==="
+          lxc launch ubuntu:22.04 test-connectivity
 
-          # Resolve squid.internal to IP address
-          SQUID_IP=$(getent hosts squid.internal | awk '{ print $1 }' | head -1)
-          if [ -z "$SQUID_IP" ]; then
-            echo "WARNING: Cannot resolve squid.internal, using hostname"
-            PROXY_URL="http://squid.internal:3128"
-          else
-            echo "Resolved squid.internal to: $SQUID_IP"
-            PROXY_URL="http://${SQUID_IP}:3128"
-          fi
+          echo "Waiting for cloud-init to complete..."
+          lxc exec test-connectivity -- cloud-init status --wait || true
 
-          echo "Testing proxy connectivity: $PROXY_URL"
-          curl -x "$PROXY_URL" -I https://cloud-images.ubuntu.com --connect-timeout 5 || echo "WARNING: Proxy test failed"
+          echo "Testing package installation:"
+          lxc exec test-connectivity -- apt-get update
 
-          echo "=== Configuring LXD proxy: ==="
-          # Configure the default profile to pass proxy environment variables to containers
-          lxc profile set default environment.HTTP_PROXY "$PROXY_URL"
-          lxc profile set default environment.HTTPS_PROXY "$PROXY_URL"
-          lxc profile set default environment.NO_PROXY "localhost,127.0.0.1,10.149.0.0/16,10.0.0.0/8"
+          echo "Testing direct connectivity:"
+          lxc exec test-connectivity -- ping -c 3 8.8.8.8 || echo "Ping failed"
 
-          echo "=== Verifying LXD profile configuration ==="
-          lxc profile show default | grep -A10 environment || true
+          echo "Testing HTTPS connectivity:"
+          lxc exec test-connectivity -- curl -I https://ubuntu.com || echo "Curl to ubuntu.com failed"
 
-          echo "=== Testing container connectivity ==="
-          lxc launch ubuntu:22.04 test-proxy-connectivity
-          sleep 10
-          lxc exec test-proxy-connectivity -- cloud-init status --wait || true
-          lxc exec test-proxy-connectivity -- apt-get update || echo "APT update failed"
-          lxc exec test-proxy-connectivity -- curl -I https://ubuntu.com || echo "Curl failed"
-          lxc delete test-proxy-connectivity --force
+          echo "Cleaning up test container..."
+          lxc delete test-connectivity --force
+
+          echo "=== LXD containers have internet connectivity ==="
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -131,7 +131,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [[ubuntu-24.04]]
+        runs-on: [[self-hosted-linux-amd64-noble-medium]]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Try to change the runner for functional test from default GitHub runner to a self-hosted runner for larger storage, to resolve the persistent issue of [not having enough free space](https://github.com/canonical/juju-backup-all/actions/runs/19252586540/job/55040620118#step:8:61). The current chosen self-hosted machine has 16 CPU and 64 GiB of memory with 100 GiB of disk (see Refs).

With this change, sometimes the functional test still failed because all units got stuck in `waiting for machine` state ([see](https://github.com/canonical/juju-backup-all/actions/runs/18894480787/job/54535046854#step:9:349)). Could it be a connectivity issue, or other issues is not easy to verify. However at the time of writing, the test succeeded 3 times in a row without any further setup, so seems like the previous failures could be inconsistent behavior and it can likely be success in reruns. Therefore it's reasonable to push forward. There is a simple step added before running functional test, which tries to create an lxd instance and check its connectivity. 

Refs: 
https://canonical-self-hosted-github-runner-docs.readthedocs-hosted.com/en/latest/usage/available_runners/
https://docs.github.com/en/actions/reference/runners/github-hosted-runners