### PR TITLE
try latest/stable for postgresql

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -131,7 +131,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [[self-hosted-linux-amd64-noble-xlarge]]
+        runs-on: [[self-hosted-linux-amd64-jammy-xlarge]]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/tests/functional/test_backup.py
+++ b/tests/functional/test_backup.py
@@ -39,7 +39,7 @@ async def test_build_and_deploy(ops_test):
         "ch:postgresql",
         application_name="postgresql",
         series="jammy",
-        channel="14/stable",
+        channel="latest/stable",
         num_units=1,
     )
     await ops_test.model.deploy(


### PR DESCRIPTION
For some reasons the postgresql charm in functional test was always in error state after being deployed. This happened on every retry (10 for now, see https://github.com/canonical/juju-backup-all/actions/runs/19385673110), which may hint this is not a transient error. 
However, it didn't happen in my local testing. The whole func test still passed with ease using exact same setup, so not sure what actually happened there, except if we can login to the test machine.
Here I try changing the `postgresql` channel from `14/stable` to `latest/stable` and the test passes here surprisingly. It may not matter about this charm on what channel, so I guess it should be fine...
