### PR TITLE
fix versioning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,10 @@ setup_requires =
 install_requires =
     attrs >= 21.2.0
     juju
+    # pin websocket due to issue #93
+    # wait for python-libjuju to resolve the breaking change
+    # in websockets 15.0.0 before allowing newer versions
+    websockets >= 13.0.1, < 15
 test_requires =
     coverage[toml]
     pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,10 +14,6 @@ setup_requires =
 install_requires =
     attrs >= 21.2.0
     juju
-    # pin websocket due to issue #93
-    # wait for python-libjuju to resolve the breaking change
-    # in websockets 15.0.0 before allowing newer versions
-    websockets >= 13.0.1, < 15
 test_requires =
     coverage[toml]
     pytest

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -91,6 +91,7 @@ parts:
       - python3-pkg-resources
       - openssh-client
     override-build: |
+      VERSION="$(python3 -m setuptools_scm)"
+      echo "Version: $VERSION"
       craftctl default
-      echo "Version: $(python3 setup.py --version)"
-      craftctl set version="$(python3 setup.py --version)"
+      craftctl set version="$VERSION"


### PR DESCRIPTION
Fix the [versioning issue](https://github.com/canonical/juju-backup-all/actions/runs/25950051404/job/76286065558#step:3:301) in snap packing caused by the deprecation of `setup.py` 
 